### PR TITLE
[stashStashboxSceneCount] find correct api_key when using multiple StashBoxes

### DIFF
--- a/plugins/stashStashboxSceneCount/stashStashboxSceneCount.js
+++ b/plugins/stashStashboxSceneCount/stashStashboxSceneCount.js
@@ -174,7 +174,7 @@
                 if (el && !el.parentElement.querySelector('.stashbox-scene-count')) {
                     const badge = createElementFromHTML(`<span class="stashbox-scene-count ml-1" style="display: none;"></span>`);
                     insertAfter(badge, el);
-                    const api_key = data.data.configuration.general.stashBoxes.find(o => o.endpoint = endpoint).api_key;
+                    const api_key = data.data.configuration.general.stashBoxes.find(o => o.endpoint == endpoint).api_key;
                     await runGetStashboxPerformerSceneCountTask(endpoint, api_key, stash_id);
                     const stashBoxSceneCount = await stash.pollLogsForMessage(`[Plugin / Stash Stashbox Scene Count] ${stash_id}: `);
                     badge.innerText = stashBoxSceneCount;
@@ -196,7 +196,7 @@
                 if (el && !el.parentElement.querySelector('.stashbox-scene-count')) {
                     const badge = createElementFromHTML(`<span class="stashbox-scene-count ml-1" style="display: none;"></span>`);
                     insertAfter(badge, el);
-                    const api_key = data.data.configuration.general.stashBoxes.find(o => o.endpoint = endpoint).api_key;
+                    const api_key = data.data.configuration.general.stashBoxes.find(o => o.endpoint == endpoint).api_key;
                     await runGetStashboxStudioSceneCountTask(endpoint, api_key, stash_id);
                     const stashBoxSceneCount = await stash.pollLogsForMessage(`[Plugin / Stash Stashbox Scene Count] ${stash_id}: `);
                     badge.innerText = stashBoxSceneCount;


### PR DESCRIPTION
When using multiple StashBoxes the plugin still uses the api_key of the first one. This fixes that.