### PR TITLE
0.27+ SceneTaggerDraftSubmit fix

### DIFF
--- a/plugins/stashSceneTaggerDraftSubmit/stashSceneTaggerDraftSubmit.js
+++ b/plugins/stashSceneTaggerDraftSubmit/stashSceneTaggerDraftSubmit.js
@@ -74,7 +74,7 @@
                     alert('No stashbox source selected.');
                     return;
                 }
-                const selectedStashboxIndex = parseInt(selectedStashbox.replace(/^stashbox:/, ''));
+                const selectedStashboxIndex = stashBoxes.findIndex(box => box.endpoint === selectedStashbox.replace(/^stashbox:/, ''));
                 const existingStashId = data.stash_ids.find(o => o.endpoint === stashBoxes[selectedStashboxIndex].endpoint);
                 if (existingStashId) {
                     alert(`Scene already has StashID for ${stashBoxes[selectedStashboxIndex].endpoint}.`);

--- a/plugins/stashSceneTaggerDraftSubmit/stashSceneTaggerDraftSubmit.yml
+++ b/plugins/stashSceneTaggerDraftSubmit/stashSceneTaggerDraftSubmit.yml
@@ -1,7 +1,7 @@
 name: Stash Scene Tagger Draft Submit
 # requires: stashUserscriptLibrary7dJx1qP
 description: Adds button to Scene Tagger to submit draft to stashdb
-version: 0.1.4
+version: 0.1.5
 url: https://github.com/7dJx1qP/stash-plugins#stash-scene-tagger-draft-submit
 ui:
   requires: 


### PR DESCRIPTION
SceneTaggerDraftSubmit  stopped working after 0.27 release, the previous method for getting the stash box index is no longer valid resulting in a NaN, refactor this for the new 0.27+ format to derive the StashBox index from the StashBox endpoint.