### PR TITLE
[stashPerformerMarkersTab] fix url format

### DIFF
--- a/plugins/stashPerformerMarkersTab/stashPerformerMarkersTab.js
+++ b/plugins/stashPerformerMarkersTab/stashPerformerMarkersTab.js
@@ -45,7 +45,7 @@
                 const markersCount = (await getPerformerMarkersCount(performerId)).data.findSceneMarkers.count;
                 document.querySelector(`#${markersTabId} span`).innerHTML = markersCount;
                 const performerName = document.querySelector('.performer-head h2').innerText;
-                const markersUrl = `${window.location.origin}/scenes/markers?c=${JSON.stringify({"type":"performers","value":[{"id":performerId,"label":performerName}],"modifier":"INCLUDES_ALL"})}`
+                const markersUrl = `${window.location.origin}/scenes/markers?c=("type":"performers","modifier":"INCLUDES_ALL","value":("items":[("id":"${performerId}","label":"${performerName}")],"excluded":[]))&sortby=created_at&sortdir=desc&disp=2`;
                 markerTab.href = markersUrl;
             }
         });


### PR DESCRIPTION
been getting an error for a bit, found the url format to be different now.

URL was formatted like 
`"value":[{"id":performerId,"label":performerName}]`

changed it to
`"value":("items":[("id":"${performerId}","label":"${performerName}")]`