### PR TITLE
Fix stash response event not triggered since stash v0.28.1-47-g815ce713

### DIFF
--- a/plugins/stashUserscriptLibrary7dJx1qP/stashUserscriptLibrary7dJx1qP.js
+++ b/plugins/stashUserscriptLibrary7dJx1qP/stashUserscriptLibrary7dJx1qP.js
@@ -13,7 +13,7 @@
             const response = await originalFetch(resource, config);
             // response interceptor here
             const contentType = response.headers.get("content-type");
-            if (contentType && contentType.indexOf("application/json") !== -1 && typeof resource === "string" && resource.endsWith('/graphql')) {
+            if (contentType && (contentType.indexOf("application/json") !== -1 || contentType.indexOf("application/graphql-response+json") !== -1) && typeof resource === "string" && resource.endsWith('/graphql')) {
                 try {
                     const data = await response.clone().json();
                     stashListener.dispatchEvent(new CustomEvent('response', { 'detail': data }));


### PR DESCRIPTION
Fixes #20
Fixes #21

A lot of the plugins actions are triggered by a single event generated from received network response.

After a bit of searching through the different layers of the plugins, I found that before dispatching events a check was made on the content type of the response.
This check mismatches on the latest version of stash, switching from the legacy value `application/json` to the recommended one `application/graphql-response+json`.
Both values have been kept to ensure retro-compatibility.

I suspect stash's gqlgenc version bump to be the culprit for this unexpected change: [af34829f38fc101a09e23424f37e40d4e63b408d](https://github.com/stashapp/stash/commit/00f5d0d9840b5a453d9b26dabfd19264b53aab1a)